### PR TITLE
Update global template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
       run: dotnet pack -o ${{ env.PACKAGE_OUPUT_DIRECTORY }} -c ${{ env.CONFIGURATION }} --include-symbols
 
     - name: Publish to NuGet
-      run: dotnet nuget push ${{ env.PACKAGE_OUPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ${{ env.PACKAGE_OUPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-    - '*'
+    - 'v*'
 
 env:
   CONFIGURATION: Release
@@ -20,12 +20,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
+        dotnet-version: 7.0.x
 
     - name: Pack solution
       run: dotnet pack -o ${{ env.PACKAGE_OUPUT_DIRECTORY }} -c ${{ env.CONFIGURATION }} --include-symbols
 
     - name: Publish to NuGet
-      run: dotnet nuget push ${{ env.PACKAGE_OUPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push ${{ env.PACKAGE_OUPUT_DIRECTORY }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,16 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore
 
     - name: Build solution
-      run: dotnet build -c ${{ env.CONFIGURATION }} --no-restore -m
+      run: dotnet build -c ${{ env.CONFIGURATION }} --no-restore
 
     - name: Run unit tests
-      run: dotnet test tests/*.Unit/*.csproj -c ${{ env.CONFIGURATION }} --no-build --collect:"XPlat Code Coverage" -m
+      run: dotnet test tests/*.Unit/*.csproj -c ${{ env.CONFIGURATION }} --no-build --collect:"XPlat Code Coverage"
 
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="Microsoft.CST.DevSkim" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.21.0" />
     <PackageVersion Include="Microsoft.CST.DevSkim" Version="1.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.1.7" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
     <PackageVersion Include="xunit" Version="2.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.21.0" />
     <PackageVersion Include="Microsoft.CST.DevSkim" Version="1.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.4.0.72892" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <config>
+    <add key="defaultPushSource" value="https://api.nuget.org/v3/index.json" />
+  </config>
   <packageRestore>
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />
@@ -8,16 +11,11 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="nuget.org">
-      <package pattern="*" />
-    </packageSource>
-  </packageSourceMapping>
   <bindingRedirects>
     <add key="skip" value="False" />
   </bindingRedirects>
   <packageManagement>
-    <add key="format" value="0" />
+    <add key="format" value="1" />
     <add key="disabled" value="False" />
   </packageManagement>
 </configuration>

--- a/src/Mafin.Template/Class1.cs
+++ b/src/Mafin.Template/Class1.cs
@@ -1,5 +1,9 @@
 namespace Mafin.Template;
 
+/// <summary>
+/// Template class.
+/// </summary>
 public class Class1
 {
+    // Intentionally empty
 }

--- a/src/Mafin.Template/Mafin.Template.csproj
+++ b/src/Mafin.Template/Mafin.Template.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
     <PackageId>Mafin.Template</PackageId>
     <Description>MAFIN Template package</Description>
     <Authors>MAFIN Squad</Authors>
@@ -10,7 +10,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version></Version>
   </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests.Unit" />
 

--- a/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
+++ b/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
+++ b/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
@@ -4,6 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />

--- a/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
+++ b/tests/Mafin.Template.Tests.Unit/Mafin.Template.Tests.Unit.csproj
@@ -10,5 +10,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="coverlet.collector" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+
+    <ProjectReference Include="..\..\src\Mafin.Template\Mafin.Template.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Mafin.Template.Tests.Unit/UnitTest1.cs
+++ b/tests/Mafin.Template.Tests.Unit/UnitTest1.cs
@@ -5,5 +5,6 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
+        true.Should().BeTrue();
     }
 }

--- a/tests/Mafin.Template.Tests.Unit/Usings.cs
+++ b/tests/Mafin.Template.Tests.Unit/Usings.cs
@@ -1,1 +1,2 @@
+global using FluentAssertions;
 global using Xunit;


### PR DESCRIPTION
* Upgrade dependencies
* Add .NET 7 to list of outputs
* Upgrade tests to .NET 7
* Add FluentAssertions to be referenced by default
* Add main project reference to test project by default
* Fix SCA warnings
* Add code duplication analysis
* Make NuGet push source pipeline agnostic
* Fix comments for pipelines from previous code reviews
* Supercede #31 
* Supercede #32 
* Supercede #33 